### PR TITLE
fix(i18n): fix Korean translation in README_KR.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 (Some of advices are implemented in [go-critic](https://github.com/go-critic/go-critic))
 
-[中文版](./README_ZH.md)
-[한국어](./README_KR.md)
+- [中文版](./README_ZH.md)
+- [한국어](./README_KR.md)
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 (Some of advices are implemented in [go-critic](https://github.com/go-critic/go-critic))
 
 [中文版](./README_ZH.md)
+[한국어](./README_KR.md)
 
 ## Contents
 


### PR DESCRIPTION
## Related Issue

Closes #59

## Summary

This PR fixes multiple issues found in the Korean translation (`README_KR.md`).

### Missing Content
- Add language links (`[中文版]`, `[한국어]`) to the header
- Restore the missing **"To prevent unkeyed literals"** section (`_ struct{}`)
- Add missing `// EVEN BETTER` example (`delay := 24 * time.Hour`)
- Replace deprecated `github.com/pkg/errors` wrapping with `fmt.Errorf("...: %w", err)`

### Typo Fixes
- `동시성(concurrency은` → `동시성(concurrency)은` (missing closing parenthesis)
- `여러러분들의` → `여러분의` (duplicated character)
- `언제 멈춰어야` → `언제 멈춰야`
- `우아하게 다뤄어라` → `우아하게 다뤄라`
- `고루틴을 버려랴` → `고루틴 덤프하기`
- `약간의의메모리 누수` → `약간의 메모리 누수`
- Broken link `4b181zkB1관` → `4b181zkB1O` (Korean character was mixed in)

### Mistranslation Fixes
- `중재는 미덕이다` → `절제는 미덕이다` ("moderation" ≠ "중재/mediation")
- Concurrency `select{}` section was translated with the **opposite meaning** ("prevent forever" vs "block forever")
- `go test -short` description was incorrect ("re-runs" → "reduces number of tests run")
- "Channels orchestrate; mutexes serialize" restructured to match original sentence

### Outdated Links & Deprecated APIs
- All `godoc.org` links → `pkg.go.dev` (godoc.org is shut down)
- Zen of Go link: `netlify.com` → `netlify.app`
- `ioutil.Discard` → `io.Discard` (deprecated since Go 1.16)
- Fixed `staticcheck` SA6002 URL format

### Style & Consistency
- Unified imperative style throughout (`~하라` form)
- `여러분들의` → `여러분의` (more natural Korean)
- Reduced excessive inline English for non-technical phrases